### PR TITLE
[FTR] Images, First & Last name, User-Events table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .env
+/cms/src/*adminsdk.json

--- a/cms/.gitignore
+++ b/cms/.gitignore
@@ -112,3 +112,5 @@ exports
 dist
 build
 .strapi-updater.json
+
+*adminsdk.json

--- a/cms/config/plugins.ts
+++ b/cms/config/plugins.ts
@@ -9,7 +9,6 @@ export default ({ env }) => ({
           user: env('SMTP_USERNAME'),
           pass: env('SMTP_PASSWORD'),
         },
-        // ... any custom nodemailer options
       },
       settings: {
         defaultFrom: 'hello@42.mk',
@@ -17,5 +16,34 @@ export default ({ env }) => ({
       },
     },
   },
-  // ...
+  upload: {
+    config: {
+      sizeLimit: 5 * 1024 * 1024,
+      security: {
+        allowedFileExtensions: [
+          '.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg',
+          '.pdf', '.doc', '.docx', '.txt',
+        ],
+        blockedFileExtensions: [
+          '.exe', '.dll', '.sh', '.bat', '.cmd', '.com',
+          '.app', '.deb', '.rpm', '.dmg', '.pkg',
+          '.js', '.ts', '.jsx', '.tsx', '.php', '.html',
+        ],
+        allowedMimeTypes: [
+          'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml',
+          'application/pdf',
+          'text/plain',
+          'application/msword',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        ],
+      },
+      breakpoints: {
+        xlarge: 1920,
+        large: 1000,
+        medium: 750,
+        small: 500,
+        xsmall: 64,
+      },
+    },
+  },
 });

--- a/cms/src/api/event/content-types/event/schema.json
+++ b/cms/src/api/event/content-types/event/schema.json
@@ -114,6 +114,12 @@
         }
       },
       "type": "string"
+    },
+    "userEvents": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::user-event.user-event",
+      "mappedBy": "event"
     }
   }
 }

--- a/cms/src/api/user-event/content-types/user-event/schema.json
+++ b/cms/src/api/user-event/content-types/user-event/schema.json
@@ -24,15 +24,10 @@
       "target": "api::event.event",
       "inversedBy": "userEvents"
     },
-    "isInterested": {
-      "type": "boolean",
-      "default": false,
-      "required": true
-    },
-    "hasAttended": {
-      "type": "boolean",
-      "default": false,
-      "required": true
+    "attendanceStatus": {
+      "type": "enumeration",
+      "enum": ["interested", "going", "attended", "cancelled"],
+      "default": "interested"
     }
   }
 }

--- a/cms/src/api/user-event/content-types/user-event/schema.json
+++ b/cms/src/api/user-event/content-types/user-event/schema.json
@@ -1,0 +1,38 @@
+{
+  "kind": "collectionType",
+  "collectionName": "user_events",
+  "info": {
+    "singularName": "user-event",
+    "pluralName": "user-events",
+    "displayName": "User Event",
+    "description": "Tracks user interest and attendance for events"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "user": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "plugin::users-permissions.user",
+      "inversedBy": "userEvents"
+    },
+    "event": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::event.event",
+      "inversedBy": "userEvents"
+    },
+    "isInterested": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "hasAttended": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    }
+  }
+}

--- a/cms/src/api/user-event/controllers/user-event.ts
+++ b/cms/src/api/user-event/controllers/user-event.ts
@@ -64,7 +64,6 @@ export default factories.createCoreController('api::user-event.user-event', ({ s
         },
       });
     } else {
-      // Create new record
       result = await strapi.documents('api::user-event.user-event').create({
         data: {
           user: userId,

--- a/cms/src/api/user-event/controllers/user-event.ts
+++ b/cms/src/api/user-event/controllers/user-event.ts
@@ -5,11 +5,11 @@
 import { factories } from '@strapi/strapi';
 
 export default factories.createCoreController('api::user-event.user-event', ({ strapi }) => ({
-  async markInterested(ctx) {
-    const { userId, eventId, isInterested } = ctx.request.body;
+  async changeStatus(ctx) {
+    const { userId, eventId, attendanceStatus } = ctx.request.body;
 
-    if (!userId || !eventId || isInterested === undefined) {
-      return ctx.badRequest('userId, eventId, and isInterested are required');
+    if (!userId || !eventId || attendanceStatus === undefined) {
+      return ctx.badRequest('userId, eventId, and attendanceStatus are required');
     }
 
     const existingRecord = await strapi.db.query('api::user-event.user-event').findOne({
@@ -24,7 +24,7 @@ export default factories.createCoreController('api::user-event.user-event', ({ s
       result = await strapi.documents('api::user-event.user-event').update({
         documentId: existingRecord.documentId,
         data: {
-          isInterested,
+          attendanceStatus,
         },
       });
     } else {
@@ -32,48 +32,11 @@ export default factories.createCoreController('api::user-event.user-event', ({ s
         data: {
           user: userId,
           event: eventId,
-          isInterested,
-          hasAttended: false,
+          attendanceStatus,
         },
       });
     }
 
     ctx.body = result;
-  },
-
-  async markAttended(ctx) {
-    const { userId, eventId, hasAttended } = ctx.request.body;
-
-    if (!userId || !eventId || hasAttended === undefined) {
-      return ctx.badRequest('userId, eventId, and hasAttended are required');
-    }
-
-    const existingRecord = await strapi.db.query('api::user-event.user-event').findOne({
-      where: {
-        user: userId,
-        event: eventId,
-      },
-    });
-
-    let result;
-    if (existingRecord) {
-      result = await strapi.documents('api::user-event.user-event').update({
-        documentId: existingRecord.documentId,
-        data: {
-          hasAttended,
-        },
-      });
-    } else {
-      result = await strapi.documents('api::user-event.user-event').create({
-        data: {
-          user: userId,
-          event: eventId,
-          isInterested: false,
-          hasAttended,
-        },
-      });
-    }
-
-    ctx.body = result;
-  },
+  }
 }));

--- a/cms/src/api/user-event/controllers/user-event.ts
+++ b/cms/src/api/user-event/controllers/user-event.ts
@@ -1,0 +1,80 @@
+/**
+ * user-event controller
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreController('api::user-event.user-event', ({ strapi }) => ({
+  async markInterested(ctx) {
+    const { userId, eventId, isInterested } = ctx.request.body;
+
+    if (!userId || !eventId || isInterested === undefined) {
+      return ctx.badRequest('userId, eventId, and isInterested are required');
+    }
+
+    const existingRecord = await strapi.db.query('api::user-event.user-event').findOne({
+      where: {
+        user: userId,
+        event: eventId,
+      },
+    });
+
+    let result;
+    if (existingRecord) {
+      result = await strapi.documents('api::user-event.user-event').update({
+        documentId: existingRecord.documentId,
+        data: {
+          isInterested,
+        },
+      });
+    } else {
+      result = await strapi.documents('api::user-event.user-event').create({
+        data: {
+          user: userId,
+          event: eventId,
+          isInterested,
+          hasAttended: false,
+        },
+      });
+    }
+
+    ctx.body = result;
+  },
+
+  async markAttended(ctx) {
+    const { userId, eventId, hasAttended } = ctx.request.body;
+
+    if (!userId || !eventId || hasAttended === undefined) {
+      return ctx.badRequest('userId, eventId, and hasAttended are required');
+    }
+
+    const existingRecord = await strapi.db.query('api::user-event.user-event').findOne({
+      where: {
+        user: userId,
+        event: eventId,
+      },
+    });
+
+    let result;
+    if (existingRecord) {
+      result = await strapi.documents('api::user-event.user-event').update({
+        documentId: existingRecord.documentId,
+        data: {
+          hasAttended,
+        },
+      });
+    } else {
+      // Create new record
+      result = await strapi.documents('api::user-event.user-event').create({
+        data: {
+          user: userId,
+          event: eventId,
+          isInterested: false,
+          hasAttended,
+        },
+      });
+    }
+
+    ctx.body = result;
+  },
+}));

--- a/cms/src/api/user-event/routes/user-event.ts
+++ b/cms/src/api/user-event/routes/user-event.ts
@@ -2,25 +2,25 @@
  * user-event router
  */
 
-import { factories } from '@strapi/strapi';
-
-const defaultRouter = factories.createCoreRouter('api::user-event.user-event');
-const customRoutes = [
-  {
-    method: 'POST',
-    path: '/user-events/mark-interested',
-    handler: 'user-event.markInterested',
-  },
-  {
-    method: 'POST',
-    path: '/user-events/mark-attended',
-    handler: 'user-event.markAttended',
-  },
-];
-
 export default {
   routes: [
-    ...(typeof defaultRouter.routes === 'function' ? defaultRouter.routes() : defaultRouter.routes),
-    ...customRoutes,
-  ]
+    {
+      method: 'POST',
+      path: '/user-events/mark-interested',
+      handler: 'user-event.markInterested',
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+    {
+      method: 'POST',
+      path: '/user-events/mark-attended',
+      handler: 'user-event.markAttended',
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+  ],
 };

--- a/cms/src/api/user-event/routes/user-event.ts
+++ b/cms/src/api/user-event/routes/user-event.ts
@@ -1,0 +1,26 @@
+/**
+ * user-event router
+ */
+
+import { factories } from '@strapi/strapi';
+
+const defaultRouter = factories.createCoreRouter('api::user-event.user-event');
+const customRoutes = [
+  {
+    method: 'POST',
+    path: '/user-events/mark-interested',
+    handler: 'user-event.markInterested',
+  },
+  {
+    method: 'POST',
+    path: '/user-events/mark-attended',
+    handler: 'user-event.markAttended',
+  },
+];
+
+export default {
+  routes: [
+    ...(typeof defaultRouter.routes === 'function' ? defaultRouter.routes() : defaultRouter.routes),
+    ...customRoutes,
+  ]
+};

--- a/cms/src/api/user-event/routes/user-event.ts
+++ b/cms/src/api/user-event/routes/user-event.ts
@@ -6,17 +6,8 @@ export default {
   routes: [
     {
       method: 'POST',
-      path: '/user-events/mark-interested',
-      handler: 'user-event.markInterested',
-      config: {
-        policies: [],
-        middlewares: [],
-      },
-    },
-    {
-      method: 'POST',
-      path: '/user-events/mark-attended',
-      handler: 'user-event.markAttended',
+      path: '/user-events/change-status',
+      handler: 'user-event.changeStatus',
       config: {
         policies: [],
         middlewares: [],

--- a/cms/src/api/user-event/services/user-event.ts
+++ b/cms/src/api/user-event/services/user-event.ts
@@ -1,0 +1,7 @@
+/**
+ * user-event service
+ */
+
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreService('api::user-event.user-event');

--- a/cms/src/extensions/users-permissions/controllers/user.ts
+++ b/cms/src/extensions/users-permissions/controllers/user.ts
@@ -1,0 +1,110 @@
+interface UpdateProfileBody {
+  username?: string;
+  firstName?: string;
+  lastName?: string;
+  profilePicture?: number;
+}
+
+const ALLOWED_FIELDS = ['username', 'firstName', 'lastName', 'profilePicture'];
+const RESERVED_NAMES = ['admin', 'root', 'system', 'moderator', 'administrator'];
+const USERNAME_REGEX = /^[a-z0-9_]{3,20}$/;
+const NAME_REGEX = /^[a-zA-Z\s\-'.]+$/;
+const SANITIZE_REGEX = /[<>\"'&]/g;
+
+function validateNameFields(fieldName: string, value: string, ctx: any) {
+  if (typeof value !== 'string' || value.length === 0) {
+    return ctx.badRequest(`${fieldName} cannot be empty`);
+  } else if (value.length < 2) {
+    return ctx.badRequest(`${fieldName} must be at least 2 characters`);
+  } else if (value.length > 50) {
+    return ctx.badRequest(`${fieldName} must be 50 characters or less`);
+  } else if (!NAME_REGEX.test(value)) {
+    return ctx.badRequest(`${fieldName} contains invalid characters`);
+  }
+}
+
+function validateUsername(username: string, ctx: any) {
+  if (!USERNAME_REGEX.test(username)) {
+     return ctx.badRequest('Username must be 3-20 characters (lowercase letters, numbers, underscores only)');
+  } else {
+    if (RESERVED_NAMES.includes(username)) {
+      return ctx.badRequest('This username is reserved');
+    }
+  }
+}
+
+function validateProfilePictureId(id: any, ctx: any) {
+  if (typeof id !== 'number' || id <= 0 || isNaN(id)) {
+    return ctx.badRequest('Invalid profile picture ID');
+  }
+}
+
+export default {
+  async updateProfile(ctx) {
+    if (!ctx.state.user) return ctx.unauthorized();
+
+    const body = ctx.request.body as UpdateProfileBody;
+    const safeData = Object.fromEntries(
+      Object.entries(body).filter(([key]) => ALLOWED_FIELDS.includes(key))
+    );
+
+    if (Object.keys(safeData).length === 0) {
+      return ctx.badRequest('No valid fields to update');
+    }
+
+    if (safeData.username) {
+      safeData.username = safeData.username.trim().toLowerCase();
+      validateUsername(safeData.username, ctx);
+
+      const existingUser = await strapi.db.query('plugin::users-permissions.user').findOne({
+        where: { username: safeData.username },
+      });
+      if (existingUser && existingUser.id !== ctx.state.user.id) {
+        return ctx.badRequest('Username is already taken');
+      }
+    }
+
+    if (safeData.firstName) {
+      safeData.firstName = safeData.firstName.trim();
+      validateNameFields('First name', safeData.firstName, ctx);
+      safeData.firstName = safeData.firstName.replace(SANITIZE_REGEX, '');
+    }
+
+    if (safeData.lastName) {
+      safeData.lastName = safeData.lastName.trim();
+      validateNameFields('Last name', safeData.lastName, ctx);
+      safeData.lastName = safeData.lastName.replace(SANITIZE_REGEX, '');
+    }
+
+    if (typeof safeData.profilePicture === 'string' && safeData.profilePicture.trim() !== '') {
+      safeData.profilePicture = parseInt(safeData.profilePicture, 10);
+      validateProfilePictureId(safeData.profilePicture, ctx);
+
+      try {
+        const media = await strapi.db.query('plugin::upload.file').findOne({
+          where: { id: safeData.profilePicture },
+          select: ['id', 'name', 'mime', 'size'],
+        });
+        const maxSizeKB = 10 * 1024;
+
+        if (!media) return ctx.badRequest('Profile picture not found');
+        if (!media.mime.startsWith('image/')) return ctx.badRequest('Profile picture must be an image');
+        if (media.size > maxSizeKB) return ctx.badRequest('Profile picture must be smaller than 10MB');
+      } catch (error) {
+        return ctx.internalServerError('Failed to validate profile picture');
+      }
+    }
+
+    try {
+      const updated = await strapi.documents('plugin::users-permissions.user').update({
+        documentId: ctx.state.user.documentId,
+        data: safeData,
+      });
+
+      const { password, resetPasswordToken, confirmationToken, ...safeUser } = updated;
+      ctx.body = safeUser;
+    } catch (error) {
+      return ctx.internalServerError('Failed to update profile');
+    }
+  },
+};

--- a/cms/src/extensions/users-permissions/routes/custom-routes.ts
+++ b/cms/src/extensions/users-permissions/routes/custom-routes.ts
@@ -1,0 +1,13 @@
+
+export default {
+  routes: [
+    {
+      method: 'PUT',
+      path: '/profile/update',
+      handler: 'user.updateProfile',
+      config: {
+        prefix: '',
+      },
+    },
+  ],
+}

--- a/cms/src/extensions/users-permissions/strapi-server.ts
+++ b/cms/src/extensions/users-permissions/strapi-server.ts
@@ -1,0 +1,26 @@
+module.exports = (plugin) => {
+  const userAttributes = plugin.contentTypes.user.schema.attributes;
+
+  userAttributes.firstName = {
+    type: 'string',
+  };
+
+  userAttributes.lastName = {
+    type: 'string',
+  };
+
+  userAttributes.profilePicture = {
+    type: 'media',
+    allowedTypes: ['images'],
+    multiple: false,
+  };
+
+  userAttributes.userEvents = {
+    type: 'relation',
+    relation: 'oneToMany',
+    target: 'api::user-event.user-event',
+    mappedBy: 'user',
+  };
+
+  return plugin;
+};

--- a/cms/src/extensions/users-permissions/strapi-server.ts
+++ b/cms/src/extensions/users-permissions/strapi-server.ts
@@ -1,3 +1,6 @@
+import customRoutes from "./routes/custom-routes";
+import userController from './controllers/user';
+
 module.exports = (plugin) => {
   const userAttributes = plugin.contentTypes.user.schema.attributes;
 
@@ -21,6 +24,10 @@ module.exports = (plugin) => {
     target: 'api::user-event.user-event',
     mappedBy: 'user',
   };
+
+  plugin.controllers.user.updateProfile = userController.updateProfile;
+
+  plugin.routes['content-api'].routes.push(...customRoutes.routes);
 
   return plugin;
 };

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -14,5 +14,42 @@ export default {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  bootstrap(/*{ strapi }*/) {},
+  bootstrap({ strapi }) {
+    strapi.cron.add({
+      cleanupPastEventInterest: {
+        task: async ({ strapi }) => {
+          const now = new Date();
+
+          const pastEvents = await strapi.db.query('api::event.event').findMany({
+            where: {
+              start: {
+                $lt: now,
+              },
+            },
+            select: ['id'],
+          });
+
+          const pastEventIds = pastEvents.map(event => event.id);
+
+          if (pastEventIds.length > 0) {
+            const deleted = await strapi.db.query('api::user-event.user-event').deleteMany({
+              where: {
+                event: {
+                  id: {
+                    $in: pastEventIds,
+                  },
+                },
+                hasAttended: false,
+              },
+            });
+
+            strapi.log.info(`Cleaned up ${deleted.count || 0} user-event records for past events`);
+          }
+        },
+        options: {
+          rule: '0 2 * * *',
+        },
+      },
+    });
+  },
 };

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -14,42 +14,5 @@ export default {
    * This gives you an opportunity to set up your data model,
    * run jobs, or perform some special logic.
    */
-  bootstrap({ strapi }) {
-    strapi.cron.add({
-      cleanupPastEventInterest: {
-        task: async ({ strapi }) => {
-          const now = new Date();
-
-          const pastEvents = await strapi.db.query('api::event.event').findMany({
-            where: {
-              start: {
-                $lt: now,
-              },
-            },
-            select: ['id'],
-          });
-
-          const pastEventIds = pastEvents.map(event => event.id);
-
-          if (pastEventIds.length > 0) {
-            const deleted = await strapi.db.query('api::user-event.user-event').deleteMany({
-              where: {
-                event: {
-                  id: {
-                    $in: pastEventIds,
-                  },
-                },
-                hasAttended: false,
-              },
-            });
-
-            strapi.log.info(`Cleaned up ${deleted.count || 0} user-event records for past events`);
-          }
-        },
-        options: {
-          rule: '0 2 * * *',
-        },
-      },
-    });
-  },
+  bootstrap(/*{ strapi }*/) {},
 };

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -563,6 +563,10 @@ export interface ApiEventEvent extends Struct.CollectionTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    userEvents: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::user-event.user-event'
+    >;
   };
 }
 
@@ -653,6 +657,45 @@ export interface ApiHomeHome extends Struct.SingleTypeSchema {
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+  };
+}
+
+export interface ApiUserEventUserEvent extends Struct.CollectionTypeSchema {
+  collectionName: 'user_events';
+  info: {
+    description: 'Tracks user interest and attendance for events';
+    displayName: 'User Event';
+    pluralName: 'user-events';
+    singularName: 'user-event';
+  };
+  options: {
+    draftAndPublish: false;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    event: Schema.Attribute.Relation<'manyToOne', 'api::event.event'>;
+    hasAttended: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<false>;
+    isInterested: Schema.Attribute.Boolean &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<false>;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::user-event.user-event'
+    > &
+      Schema.Attribute.Private;
+    publishedAt: Schema.Attribute.DateTime;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    user: Schema.Attribute.Relation<
+      'manyToOne',
+      'plugin::users-permissions.user'
+    >;
   };
 }
 
@@ -1125,6 +1168,8 @@ export interface PluginUsersPermissionsUser
       Schema.Attribute.SetMinMaxLength<{
         minLength: 6;
       }>;
+    firstName: Schema.Attribute.String;
+    lastName: Schema.Attribute.String;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
@@ -1136,6 +1181,7 @@ export interface PluginUsersPermissionsUser
       Schema.Attribute.SetMinMaxLength<{
         minLength: 6;
       }>;
+    profilePicture: Schema.Attribute.Media<'images'>;
     provider: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
     resetPasswordToken: Schema.Attribute.String & Schema.Attribute.Private;
@@ -1146,6 +1192,10 @@ export interface PluginUsersPermissionsUser
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    userEvents: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::user-event.user-event'
+    >;
     username: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.Unique &
@@ -1170,6 +1220,7 @@ declare module '@strapi/strapi' {
       'api::event.event': ApiEventEvent;
       'api::gallery.gallery': ApiGalleryGallery;
       'api::home.home': ApiHomeHome;
+      'api::user-event.user-event': ApiUserEventUserEvent;
       'plugin::content-releases.release': PluginContentReleasesRelease;
       'plugin::content-releases.release-action': PluginContentReleasesReleaseAction;
       'plugin::i18n.locale': PluginI18NLocale;

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -22,45 +22,45 @@ export interface AdminApiToken extends Struct.CollectionTypeSchema {
   };
   attributes: {
     accessKey: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     description: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }> &
-      Schema.Attribute.DefaultTo<''>;
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }> &
+    Schema.Attribute.DefaultTo<''>;
     encryptedKey: Schema.Attribute.Text &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     expiresAt: Schema.Attribute.DateTime;
     lastUsedAt: Schema.Attribute.DateTime;
     lifespan: Schema.Attribute.BigInteger;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::api-token'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.Unique &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     permissions: Schema.Attribute.Relation<
       'oneToMany',
       'admin::api-token-permission'
     >;
     publishedAt: Schema.Attribute.DateTime;
     type: Schema.Attribute.Enumeration<['read-only', 'full-access', 'custom']> &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<'read-only'>;
+    Schema.Attribute.Required &
+    Schema.Attribute.DefaultTo<'read-only'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -86,24 +86,24 @@ export interface AdminApiTokenPermission extends Struct.CollectionTypeSchema {
   };
   attributes: {
     action: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'admin::api-token-permission'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     token: Schema.Attribute.Relation<'manyToOne', 'admin::api-token'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -129,28 +129,28 @@ export interface AdminPermission extends Struct.CollectionTypeSchema {
   };
   attributes: {
     action: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     actionParameters: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
     conditions: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<[]>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::permission'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     properties: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
     publishedAt: Schema.Attribute.DateTime;
     role: Schema.Attribute.Relation<'manyToOne', 'admin::role'>;
     subject: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -176,29 +176,29 @@ export interface AdminRole extends Struct.CollectionTypeSchema {
   };
   attributes: {
     code: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.Unique &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     description: Schema.Attribute.String;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::role'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.Unique &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     permissions: Schema.Attribute.Relation<'oneToMany', 'admin::permission'>;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     users: Schema.Attribute.Relation<'manyToMany', 'admin::user'>;
   };
 }
@@ -231,32 +231,32 @@ export interface AdminSession extends Struct.CollectionTypeSchema {
     childId: Schema.Attribute.String & Schema.Attribute.Private;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     deviceId: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private;
+    Schema.Attribute.Required &
+    Schema.Attribute.Private;
     expiresAt: Schema.Attribute.DateTime &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private;
+    Schema.Attribute.Required &
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::session'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     origin: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private;
+    Schema.Attribute.Required &
+    Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     sessionId: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private &
-      Schema.Attribute.Unique;
+    Schema.Attribute.Required &
+    Schema.Attribute.Private &
+    Schema.Attribute.Unique;
     status: Schema.Attribute.String & Schema.Attribute.Private;
     type: Schema.Attribute.String & Schema.Attribute.Private;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     userId: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private;
+    Schema.Attribute.Required &
+    Schema.Attribute.Private;
   };
 }
 
@@ -282,18 +282,18 @@ export interface AdminTransferToken extends Struct.CollectionTypeSchema {
   };
   attributes: {
     accessKey: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     description: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }> &
-      Schema.Attribute.DefaultTo<''>;
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }> &
+    Schema.Attribute.DefaultTo<''>;
     expiresAt: Schema.Attribute.DateTime;
     lastUsedAt: Schema.Attribute.DateTime;
     lifespan: Schema.Attribute.BigInteger;
@@ -302,13 +302,13 @@ export interface AdminTransferToken extends Struct.CollectionTypeSchema {
       'oneToMany',
       'admin::transfer-token'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.Unique &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     permissions: Schema.Attribute.Relation<
       'oneToMany',
       'admin::transfer-token-permission'
@@ -316,7 +316,7 @@ export interface AdminTransferToken extends Struct.CollectionTypeSchema {
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -343,24 +343,24 @@ export interface AdminTransferTokenPermission
   };
   attributes: {
     action: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'admin::transfer-token-permission'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     token: Schema.Attribute.Relation<'manyToOne', 'admin::transfer-token'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -386,46 +386,46 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
   };
   attributes: {
     blocked: Schema.Attribute.Boolean &
-      Schema.Attribute.Private &
-      Schema.Attribute.DefaultTo<false>;
+    Schema.Attribute.Private &
+    Schema.Attribute.DefaultTo<false>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     email: Schema.Attribute.Email &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.Private &
+    Schema.Attribute.Unique &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 6;
+    }>;
     firstname: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     isActive: Schema.Attribute.Boolean &
-      Schema.Attribute.Private &
-      Schema.Attribute.DefaultTo<false>;
+    Schema.Attribute.Private &
+    Schema.Attribute.DefaultTo<false>;
     lastname: Schema.Attribute.String &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     password: Schema.Attribute.Password &
-      Schema.Attribute.Private &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
+    Schema.Attribute.Private &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 6;
+    }>;
     preferedLanguage: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
     registrationToken: Schema.Attribute.String & Schema.Attribute.Private;
     resetPasswordToken: Schema.Attribute.String & Schema.Attribute.Private;
     roles: Schema.Attribute.Relation<'manyToMany', 'admin::role'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     username: Schema.Attribute.String;
   };
 }
@@ -445,7 +445,7 @@ export interface ApiEventRequestEventRequest
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     eventAgenda: Schema.Attribute.RichText;
     eventDate: Schema.Attribute.Date;
     eventEnd: Schema.Attribute.Time;
@@ -463,14 +463,14 @@ export interface ApiEventRequestEventRequest
       'oneToMany',
       'api::event-request.event-request'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     organization: Schema.Attribute.String;
     organizingEntity: Schema.Attribute.String;
     physicalPresence: Schema.Attribute.Boolean;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -492,77 +492,77 @@ export interface ApiEventEvent extends Struct.CollectionTypeSchema {
   };
   attributes: {
     calendarUrl: Schema.Attribute.String &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     description: Schema.Attribute.RichText &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::event.event'>;
     photos: Schema.Attribute.Media<
       'images' | 'files' | 'videos' | 'audios',
       true
     > &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     promo: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     publishedAt: Schema.Attribute.DateTime;
     registerLink: Schema.Attribute.String &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     slug: Schema.Attribute.UID &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     start: Schema.Attribute.DateTime &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     summary: Schema.Attribute.Text &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     tags: Schema.Attribute.Component<'event-data.tags', true> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     title: Schema.Attribute.RichText &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     userEvents: Schema.Attribute.Relation<
       'oneToMany',
       'api::user-event.user-event'
@@ -584,7 +584,7 @@ export interface ApiGalleryGallery extends Struct.CollectionTypeSchema {
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     images: Schema.Attribute.Media<
       'images' | 'files' | 'videos' | 'audios',
       true
@@ -594,13 +594,13 @@ export interface ApiGalleryGallery extends Struct.CollectionTypeSchema {
       'oneToMany',
       'api::gallery.gallery'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
     slug: Schema.Attribute.UID<'name'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -622,41 +622,41 @@ export interface ApiHomeHome extends Struct.SingleTypeSchema {
   };
   attributes: {
     Content: Schema.Attribute.RichText &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     Footer: Schema.Attribute.RichText &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     gallery: Schema.Attribute.Media<
       'images' | 'files' | 'videos' | 'audios',
       true
     > &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     Hero: Schema.Attribute.RichText &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::home.home'>;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -678,48 +678,48 @@ export interface ApiPartnerPartner extends Struct.CollectionTypeSchema {
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     description: Schema.Attribute.Text &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'api::partner.partner'
     >;
     logo: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     name: Schema.Attribute.String &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     publishedAt: Schema.Attribute.DateTime;
     type: Schema.Attribute.Enumeration<
       ['tech_community', 'culture_community', 'company', 'supporter', 'sponsor']
     > &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     website: Schema.Attribute.String &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true;
-        };
-      }>;
+    Schema.Attribute.SetPluginOptions<{
+      i18n: {
+        localized: true;
+      };
+    }>;
   };
 }
 
@@ -737,24 +737,24 @@ export interface ApiUserEventUserEvent extends Struct.CollectionTypeSchema {
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     event: Schema.Attribute.Relation<'manyToOne', 'api::event.event'>;
     hasAttended: Schema.Attribute.Boolean &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<false>;
+    Schema.Attribute.Required &
+    Schema.Attribute.DefaultTo<false>;
     isInterested: Schema.Attribute.Boolean &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<false>;
+    Schema.Attribute.Required &
+    Schema.Attribute.DefaultTo<false>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'api::user-event.user-event'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     user: Schema.Attribute.Relation<
       'manyToOne',
       'plugin::users-permissions.user'
@@ -788,13 +788,13 @@ export interface PluginContentReleasesRelease
     >;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::content-releases.release'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String & Schema.Attribute.Required;
     publishedAt: Schema.Attribute.DateTime;
     releasedAt: Schema.Attribute.DateTime;
@@ -802,11 +802,11 @@ export interface PluginContentReleasesRelease
     status: Schema.Attribute.Enumeration<
       ['ready', 'blocked', 'failed', 'done', 'empty']
     > &
-      Schema.Attribute.Required;
+    Schema.Attribute.Required;
     timezone: Schema.Attribute.String;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -833,7 +833,7 @@ export interface PluginContentReleasesReleaseAction
     contentType: Schema.Attribute.String & Schema.Attribute.Required;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     entryDocumentId: Schema.Attribute.String;
     isEntryValid: Schema.Attribute.Boolean;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
@@ -841,17 +841,17 @@ export interface PluginContentReleasesReleaseAction
       'oneToMany',
       'plugin::content-releases.release-action'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     release: Schema.Attribute.Relation<
       'manyToOne',
       'plugin::content-releases.release'
     >;
     type: Schema.Attribute.Enumeration<['publish', 'unpublish']> &
-      Schema.Attribute.Required;
+    Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -879,25 +879,25 @@ export interface PluginI18NLocale extends Struct.CollectionTypeSchema {
     code: Schema.Attribute.String & Schema.Attribute.Unique;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::i18n.locale'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String &
-      Schema.Attribute.SetMinMax<
-        {
-          max: 50;
-          min: 1;
-        },
-        number
-      >;
+    Schema.Attribute.SetMinMax<
+      {
+        max: 50;
+        min: 1;
+      },
+      number
+    >;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -924,20 +924,20 @@ export interface PluginReviewWorkflowsWorkflow
   };
   attributes: {
     contentTypes: Schema.Attribute.JSON &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<'[]'>;
+    Schema.Attribute.Required &
+    Schema.Attribute.DefaultTo<'[]'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::review-workflows.workflow'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
+    Schema.Attribute.Required &
+    Schema.Attribute.Unique;
     publishedAt: Schema.Attribute.DateTime;
     stageRequiredToPublish: Schema.Attribute.Relation<
       'oneToOne',
@@ -949,7 +949,7 @@ export interface PluginReviewWorkflowsWorkflow
     >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -979,19 +979,19 @@ export interface PluginReviewWorkflowsWorkflowStage
     color: Schema.Attribute.String & Schema.Attribute.DefaultTo<'#4945FF'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::review-workflows.workflow-stage'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String;
     permissions: Schema.Attribute.Relation<'manyToMany', 'admin::permission'>;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     workflow: Schema.Attribute.Relation<
       'manyToOne',
       'plugin::review-workflows.workflow'
@@ -1023,16 +1023,16 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     caption: Schema.Attribute.Text;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     ext: Schema.Attribute.String;
     folder: Schema.Attribute.Relation<'manyToOne', 'plugin::upload.folder'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     folderPath: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Private &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.Private &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     formats: Schema.Attribute.JSON;
     hash: Schema.Attribute.String & Schema.Attribute.Required;
     height: Schema.Attribute.Integer;
@@ -1041,7 +1041,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
       'oneToMany',
       'plugin::upload.file'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     mime: Schema.Attribute.String & Schema.Attribute.Required;
     name: Schema.Attribute.String & Schema.Attribute.Required;
     previewUrl: Schema.Attribute.Text;
@@ -1052,7 +1052,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     size: Schema.Attribute.Decimal & Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     url: Schema.Attribute.Text & Schema.Attribute.Required;
     width: Schema.Attribute.Integer;
   };
@@ -1080,32 +1080,32 @@ export interface PluginUploadFolder extends Struct.CollectionTypeSchema {
     children: Schema.Attribute.Relation<'oneToMany', 'plugin::upload.folder'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     files: Schema.Attribute.Relation<'oneToMany', 'plugin::upload.file'>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::upload.folder'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     parent: Schema.Attribute.Relation<'manyToOne', 'plugin::upload.folder'>;
     path: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 1;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 1;
+    }>;
     pathId: Schema.Attribute.Integer &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique;
+    Schema.Attribute.Required &
+    Schema.Attribute.Unique;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -1134,13 +1134,13 @@ export interface PluginUsersPermissionsPermission
     action: Schema.Attribute.String & Schema.Attribute.Required;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::users-permissions.permission'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     role: Schema.Attribute.Relation<
       'manyToOne',
@@ -1148,7 +1148,7 @@ export interface PluginUsersPermissionsPermission
     >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
   };
 }
 
@@ -1176,19 +1176,19 @@ export interface PluginUsersPermissionsRole
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     description: Schema.Attribute.String;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::users-permissions.role'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     name: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 3;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 3;
+    }>;
     permissions: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::users-permissions.permission'
@@ -1197,7 +1197,7 @@ export interface PluginUsersPermissionsRole
     type: Schema.Attribute.String & Schema.Attribute.Unique;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     users: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::users-permissions.user'
@@ -1225,12 +1225,12 @@ export interface PluginUsersPermissionsUser
     confirmed: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     email: Schema.Attribute.Email &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 6;
+    }>;
     firstName: Schema.Attribute.String;
     lastName: Schema.Attribute.String;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
@@ -1238,12 +1238,12 @@ export interface PluginUsersPermissionsUser
       'oneToMany',
       'plugin::users-permissions.user'
     > &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     password: Schema.Attribute.Password &
-      Schema.Attribute.Private &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 6;
-      }>;
+    Schema.Attribute.Private &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 6;
+    }>;
     profilePicture: Schema.Attribute.Media<'images'>;
     provider: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
@@ -1254,17 +1254,17 @@ export interface PluginUsersPermissionsUser
     >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-      Schema.Attribute.Private;
+    Schema.Attribute.Private;
     userEvents: Schema.Attribute.Relation<
       'oneToMany',
       'api::user-event.user-event'
     >;
     username: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.Unique &
-      Schema.Attribute.SetMinMaxLength<{
-        minLength: 3;
-      }>;
+    Schema.Attribute.Required &
+    Schema.Attribute.Unique &
+    Schema.Attribute.SetMinMaxLength<{
+      minLength: 3;
+    }>;
   };
 }
 

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -672,16 +672,14 @@ export interface ApiUserEventUserEvent extends Struct.CollectionTypeSchema {
     draftAndPublish: false;
   };
   attributes: {
+    attendanceStatus: Schema.Attribute.Enumeration<
+      ['interested', 'going', 'attended', 'cancelled']
+    > &
+      Schema.Attribute.DefaultTo<'interested'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
     event: Schema.Attribute.Relation<'manyToOne', 'api::event.event'>;
-    hasAttended: Schema.Attribute.Boolean &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<false>;
-    isInterested: Schema.Attribute.Boolean &
-      Schema.Attribute.Required &
-      Schema.Attribute.DefaultTo<false>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',


### PR DESCRIPTION
This PR extends the user model with the following attributes: First name, Last name, Profile picture.
In addition to handle attendance, I added a user-events many-to-many table that has an additional attribute for attendance status (interested, going, cancelled, attended);

Changes:
- Profile Update Endpoint PUT /api/profile/update. Validates username uniqueness, name format, and profile picture constraints (10MB max, image-only, and only const `ALLOWED_FIELDS = ['username', 'firstName', 'lastName', 'profilePicture'];`)
    - Input Sanitization: removes dangerous characters and normalizes user inputs (trim, lowercase)
    - File Upload Security: Type, size, and existence validation for profile pictures integrated with Strapi's upload plugin
- Error Handling: Early returns with appropriate HTTP status codes (400 for validation, 500 for system errors)