### PR TITLE
[FTR] Extending the default keycloak provider

### DIFF
--- a/cms/src/extensions/users-permissions/controllers/user.ts
+++ b/cms/src/extensions/users-permissions/controllers/user.ts
@@ -107,4 +107,24 @@ export default {
       return ctx.internalServerError('Failed to update profile');
     }
   },
+
+  async saveFcmToken(ctx) {
+    if (!ctx.state.user) {
+      return ctx.unauthorized('You must be logged in');
+    }
+    const token = ctx.request.body.token || ctx.request.body.fcmToken;
+
+    if (!token) {
+      strapi.log.warn(`No FCM token provided. Body: ${JSON.stringify(ctx.request.body)}`);
+      return ctx.badRequest('FCM token is required');
+    }
+
+    await strapi.entityService.update(
+      'plugin::users-permissions.user',
+      ctx.state.user.id,
+      { data: { fcmToken: token } }
+    );
+
+    ctx.body = { ok: true };
+  },
 };

--- a/cms/src/extensions/users-permissions/routes/custom-routes.ts
+++ b/cms/src/extensions/users-permissions/routes/custom-routes.ts
@@ -9,5 +9,13 @@ export default {
         prefix: '',
       },
     },
+    {
+      method: 'POST',
+      path: '/auth/fcmToken',
+      handler: 'user.saveFcmToken',
+      config: {
+        prefix: '',
+      },
+    },
   ],
 }

--- a/cms/src/extensions/users-permissions/strapi-server.ts
+++ b/cms/src/extensions/users-permissions/strapi-server.ts
@@ -31,6 +31,7 @@ module.exports = (plugin) => {
   };
 
   plugin.controllers.user.updateProfile = userController.updateProfile;
+  plugin.controllers.user.saveFcmToken = userController.saveFcmToken;
 
   plugin.routes['content-api'].routes.push(...customRoutes.routes);
 

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -13,36 +13,35 @@ export default {
    * This gives you an opportunity to extend code.
    */
   register({ strapi }) {
-    strapi.documents.use(eventNotificationMiddleware());
 
-    strapi.plugin('users-permissions').controllers.auth.saveFcmToken = async (ctx) => {
-      if (!ctx.state.user) {
-        return ctx.unauthorized('You must be logged in');
-      }
-      const token = ctx.request.body.token || ctx.request.body.fcmToken;
+    // Override the default Keycloak provider to fetch user info
+    // from the Keycloak userinfo endpoint
+    const registry = strapi
+      .plugin('users-permissions')
+      .service('providers-registry');
 
-      if (!token) {
-        strapi.log.warn(`No FCM token provided. Body: ${JSON.stringify(ctx.request.body)}`);
-        return ctx.badRequest('FCM token is required');
-      }
+    const defaultKeycloakProvider = registry.get('keycloak');
 
-      await strapi.entityService.update(
-        'plugin::users-permissions.user',
-        ctx.state.user.id,
-        { data: { fcmToken: token } }
-      );
+    registry.add('keycloak', {
+      ...defaultKeycloakProvider,
+      async authCallback({ accessToken, providers, purest }) {
+        const keycloak = purest({ provider: 'keycloak' });
 
-      ctx.body = { ok: true };
-    };
-
-    strapi.plugin('users-permissions').routes['content-api'].routes.push({
-      method: 'POST',
-      path: '/auth/fcmToken',
-      handler: 'auth.saveFcmToken',
-      config: {
-        prefix: '',
+        return keycloak
+          .subdomain(providers.keycloak.subdomain)
+          .get('protocol/openid-connect/userinfo')
+          .auth(accessToken)
+          .request()
+          .then(({ body }) => ({
+            username: body.preferred_username,
+            email: body.email,
+            firstName: body.given_name,
+            lastName: body.family_name,
+          }));
       },
     });
+
+    strapi.documents.use(eventNotificationMiddleware());
   },
 
   /**

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -22,45 +22,45 @@ export interface AdminApiToken extends Struct.CollectionTypeSchema {
   };
   attributes: {
     accessKey: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     description: Schema.Attribute.String &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }> &
-    Schema.Attribute.DefaultTo<''>;
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Schema.Attribute.DefaultTo<''>;
     encryptedKey: Schema.Attribute.Text &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     expiresAt: Schema.Attribute.DateTime;
     lastUsedAt: Schema.Attribute.DateTime;
     lifespan: Schema.Attribute.BigInteger;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::api-token'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Unique &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     permissions: Schema.Attribute.Relation<
       'oneToMany',
       'admin::api-token-permission'
     >;
     publishedAt: Schema.Attribute.DateTime;
     type: Schema.Attribute.Enumeration<['read-only', 'full-access', 'custom']> &
-    Schema.Attribute.Required &
-    Schema.Attribute.DefaultTo<'read-only'>;
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'read-only'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -86,24 +86,24 @@ export interface AdminApiTokenPermission extends Struct.CollectionTypeSchema {
   };
   attributes: {
     action: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'admin::api-token-permission'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     token: Schema.Attribute.Relation<'manyToOne', 'admin::api-token'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -129,28 +129,28 @@ export interface AdminPermission extends Struct.CollectionTypeSchema {
   };
   attributes: {
     action: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     actionParameters: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
     conditions: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<[]>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::permission'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     properties: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<{}>;
     publishedAt: Schema.Attribute.DateTime;
     role: Schema.Attribute.Relation<'manyToOne', 'admin::role'>;
     subject: Schema.Attribute.String &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -176,29 +176,29 @@ export interface AdminRole extends Struct.CollectionTypeSchema {
   };
   attributes: {
     code: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Unique &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     description: Schema.Attribute.String;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::role'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Unique &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     permissions: Schema.Attribute.Relation<'oneToMany', 'admin::permission'>;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     users: Schema.Attribute.Relation<'manyToMany', 'admin::user'>;
   };
 }
@@ -231,32 +231,32 @@ export interface AdminSession extends Struct.CollectionTypeSchema {
     childId: Schema.Attribute.String & Schema.Attribute.Private;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     deviceId: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Private;
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
     expiresAt: Schema.Attribute.DateTime &
-    Schema.Attribute.Required &
-    Schema.Attribute.Private;
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::session'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     origin: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Private;
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     sessionId: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Private &
-    Schema.Attribute.Unique;
+      Schema.Attribute.Required &
+      Schema.Attribute.Private &
+      Schema.Attribute.Unique;
     status: Schema.Attribute.String & Schema.Attribute.Private;
     type: Schema.Attribute.String & Schema.Attribute.Private;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     userId: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Private;
+      Schema.Attribute.Required &
+      Schema.Attribute.Private;
   };
 }
 
@@ -282,18 +282,18 @@ export interface AdminTransferToken extends Struct.CollectionTypeSchema {
   };
   attributes: {
     accessKey: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     description: Schema.Attribute.String &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }> &
-    Schema.Attribute.DefaultTo<''>;
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }> &
+      Schema.Attribute.DefaultTo<''>;
     expiresAt: Schema.Attribute.DateTime;
     lastUsedAt: Schema.Attribute.DateTime;
     lifespan: Schema.Attribute.BigInteger;
@@ -302,13 +302,13 @@ export interface AdminTransferToken extends Struct.CollectionTypeSchema {
       'oneToMany',
       'admin::transfer-token'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Unique &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     permissions: Schema.Attribute.Relation<
       'oneToMany',
       'admin::transfer-token-permission'
@@ -316,7 +316,7 @@ export interface AdminTransferToken extends Struct.CollectionTypeSchema {
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -343,24 +343,24 @@ export interface AdminTransferTokenPermission
   };
   attributes: {
     action: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'admin::transfer-token-permission'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     token: Schema.Attribute.Relation<'manyToOne', 'admin::transfer-token'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -386,46 +386,46 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
   };
   attributes: {
     blocked: Schema.Attribute.Boolean &
-    Schema.Attribute.Private &
-    Schema.Attribute.DefaultTo<false>;
+      Schema.Attribute.Private &
+      Schema.Attribute.DefaultTo<false>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     email: Schema.Attribute.Email &
-    Schema.Attribute.Required &
-    Schema.Attribute.Private &
-    Schema.Attribute.Unique &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 6;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.Private &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
     firstname: Schema.Attribute.String &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     isActive: Schema.Attribute.Boolean &
-    Schema.Attribute.Private &
-    Schema.Attribute.DefaultTo<false>;
+      Schema.Attribute.Private &
+      Schema.Attribute.DefaultTo<false>;
     lastname: Schema.Attribute.String &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<'oneToMany', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     password: Schema.Attribute.Password &
-    Schema.Attribute.Private &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 6;
-    }>;
+      Schema.Attribute.Private &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
     preferedLanguage: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
     registrationToken: Schema.Attribute.String & Schema.Attribute.Private;
     resetPasswordToken: Schema.Attribute.String & Schema.Attribute.Private;
     roles: Schema.Attribute.Relation<'manyToMany', 'admin::role'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     username: Schema.Attribute.String;
   };
 }
@@ -445,7 +445,7 @@ export interface ApiEventRequestEventRequest
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     eventAgenda: Schema.Attribute.RichText;
     eventDate: Schema.Attribute.Date;
     eventEnd: Schema.Attribute.Time;
@@ -463,14 +463,14 @@ export interface ApiEventRequestEventRequest
       'oneToMany',
       'api::event-request.event-request'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     organization: Schema.Attribute.String;
     organizingEntity: Schema.Attribute.String;
     physicalPresence: Schema.Attribute.Boolean;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -492,77 +492,77 @@ export interface ApiEventEvent extends Struct.CollectionTypeSchema {
   };
   attributes: {
     calendarUrl: Schema.Attribute.String &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     description: Schema.Attribute.RichText &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::event.event'>;
     photos: Schema.Attribute.Media<
       'images' | 'files' | 'videos' | 'audios',
       true
     > &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     promo: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     publishedAt: Schema.Attribute.DateTime;
     registerLink: Schema.Attribute.String &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     slug: Schema.Attribute.UID &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     start: Schema.Attribute.DateTime &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     summary: Schema.Attribute.Text &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     tags: Schema.Attribute.Component<'event-data.tags', true> &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     title: Schema.Attribute.RichText &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     userEvents: Schema.Attribute.Relation<
       'oneToMany',
       'api::user-event.user-event'
@@ -584,7 +584,7 @@ export interface ApiGalleryGallery extends Struct.CollectionTypeSchema {
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     images: Schema.Attribute.Media<
       'images' | 'files' | 'videos' | 'audios',
       true
@@ -594,13 +594,13 @@ export interface ApiGalleryGallery extends Struct.CollectionTypeSchema {
       'oneToMany',
       'api::gallery.gallery'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
     slug: Schema.Attribute.UID<'name'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -622,41 +622,41 @@ export interface ApiHomeHome extends Struct.SingleTypeSchema {
   };
   attributes: {
     Content: Schema.Attribute.RichText &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     Footer: Schema.Attribute.RichText &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     gallery: Schema.Attribute.Media<
       'images' | 'files' | 'videos' | 'audios',
       true
     > &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     Hero: Schema.Attribute.RichText &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::home.home'>;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -678,48 +678,48 @@ export interface ApiPartnerPartner extends Struct.CollectionTypeSchema {
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     description: Schema.Attribute.Text &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'api::partner.partner'
     >;
     logo: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     name: Schema.Attribute.String &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     publishedAt: Schema.Attribute.DateTime;
     type: Schema.Attribute.Enumeration<
       ['tech_community', 'culture_community', 'company', 'supporter', 'sponsor']
     > &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     website: Schema.Attribute.String &
-    Schema.Attribute.SetPluginOptions<{
-      i18n: {
-        localized: true;
-      };
-    }>;
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true;
+        };
+      }>;
   };
 }
 
@@ -741,18 +741,18 @@ export interface ApiUserEventUserEvent extends Struct.CollectionTypeSchema {
       Schema.Attribute.DefaultTo<'interested'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     event: Schema.Attribute.Relation<'manyToOne', 'api::event.event'>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'api::user-event.user-event'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     user: Schema.Attribute.Relation<
       'manyToOne',
       'plugin::users-permissions.user'
@@ -786,13 +786,13 @@ export interface PluginContentReleasesRelease
     >;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::content-releases.release'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String & Schema.Attribute.Required;
     publishedAt: Schema.Attribute.DateTime;
     releasedAt: Schema.Attribute.DateTime;
@@ -800,11 +800,11 @@ export interface PluginContentReleasesRelease
     status: Schema.Attribute.Enumeration<
       ['ready', 'blocked', 'failed', 'done', 'empty']
     > &
-    Schema.Attribute.Required;
+      Schema.Attribute.Required;
     timezone: Schema.Attribute.String;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -831,7 +831,7 @@ export interface PluginContentReleasesReleaseAction
     contentType: Schema.Attribute.String & Schema.Attribute.Required;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     entryDocumentId: Schema.Attribute.String;
     isEntryValid: Schema.Attribute.Boolean;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
@@ -839,17 +839,17 @@ export interface PluginContentReleasesReleaseAction
       'oneToMany',
       'plugin::content-releases.release-action'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     release: Schema.Attribute.Relation<
       'manyToOne',
       'plugin::content-releases.release'
     >;
     type: Schema.Attribute.Enumeration<['publish', 'unpublish']> &
-    Schema.Attribute.Required;
+      Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -877,25 +877,25 @@ export interface PluginI18NLocale extends Struct.CollectionTypeSchema {
     code: Schema.Attribute.String & Schema.Attribute.Unique;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::i18n.locale'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String &
-    Schema.Attribute.SetMinMax<
-      {
-        max: 50;
-        min: 1;
-      },
-      number
-    >;
+      Schema.Attribute.SetMinMax<
+        {
+          max: 50;
+          min: 1;
+        },
+        number
+      >;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -922,20 +922,20 @@ export interface PluginReviewWorkflowsWorkflow
   };
   attributes: {
     contentTypes: Schema.Attribute.JSON &
-    Schema.Attribute.Required &
-    Schema.Attribute.DefaultTo<'[]'>;
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'[]'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::review-workflows.workflow'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Unique;
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
     publishedAt: Schema.Attribute.DateTime;
     stageRequiredToPublish: Schema.Attribute.Relation<
       'oneToOne',
@@ -947,7 +947,7 @@ export interface PluginReviewWorkflowsWorkflow
     >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -977,19 +977,19 @@ export interface PluginReviewWorkflowsWorkflowStage
     color: Schema.Attribute.String & Schema.Attribute.DefaultTo<'#4945FF'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::review-workflows.workflow-stage'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String;
     permissions: Schema.Attribute.Relation<'manyToMany', 'admin::permission'>;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     workflow: Schema.Attribute.Relation<
       'manyToOne',
       'plugin::review-workflows.workflow'
@@ -1021,16 +1021,16 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     caption: Schema.Attribute.Text;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     ext: Schema.Attribute.String;
     folder: Schema.Attribute.Relation<'manyToOne', 'plugin::upload.folder'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     folderPath: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Private &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.Private &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     formats: Schema.Attribute.JSON;
     hash: Schema.Attribute.String & Schema.Attribute.Required;
     height: Schema.Attribute.Integer;
@@ -1039,7 +1039,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
       'oneToMany',
       'plugin::upload.file'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     mime: Schema.Attribute.String & Schema.Attribute.Required;
     name: Schema.Attribute.String & Schema.Attribute.Required;
     previewUrl: Schema.Attribute.Text;
@@ -1050,7 +1050,7 @@ export interface PluginUploadFile extends Struct.CollectionTypeSchema {
     size: Schema.Attribute.Decimal & Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     url: Schema.Attribute.Text & Schema.Attribute.Required;
     width: Schema.Attribute.Integer;
   };
@@ -1078,32 +1078,32 @@ export interface PluginUploadFolder extends Struct.CollectionTypeSchema {
     children: Schema.Attribute.Relation<'oneToMany', 'plugin::upload.folder'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     files: Schema.Attribute.Relation<'oneToMany', 'plugin::upload.file'>;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::upload.folder'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     parent: Schema.Attribute.Relation<'manyToOne', 'plugin::upload.folder'>;
     path: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 1;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     pathId: Schema.Attribute.Integer &
-    Schema.Attribute.Required &
-    Schema.Attribute.Unique;
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -1132,13 +1132,13 @@ export interface PluginUsersPermissionsPermission
     action: Schema.Attribute.String & Schema.Attribute.Required;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::users-permissions.permission'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     role: Schema.Attribute.Relation<
       'manyToOne',
@@ -1146,7 +1146,7 @@ export interface PluginUsersPermissionsPermission
     >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
   };
 }
 
@@ -1174,19 +1174,19 @@ export interface PluginUsersPermissionsRole
   attributes: {
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     description: Schema.Attribute.String;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
     localizations: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::users-permissions.role'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     name: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 3;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 3;
+      }>;
     permissions: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::users-permissions.permission'
@@ -1195,7 +1195,7 @@ export interface PluginUsersPermissionsRole
     type: Schema.Attribute.String & Schema.Attribute.Unique;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     users: Schema.Attribute.Relation<
       'oneToMany',
       'plugin::users-permissions.user'
@@ -1223,12 +1223,12 @@ export interface PluginUsersPermissionsUser
     confirmed: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     email: Schema.Attribute.Email &
-    Schema.Attribute.Required &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 6;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
     fcmToken: Schema.Attribute.String & Schema.Attribute.Private;
     firstName: Schema.Attribute.String;
     lastName: Schema.Attribute.String;
@@ -1237,12 +1237,12 @@ export interface PluginUsersPermissionsUser
       'oneToMany',
       'plugin::users-permissions.user'
     > &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     password: Schema.Attribute.Password &
-    Schema.Attribute.Private &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 6;
-    }>;
+      Schema.Attribute.Private &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 6;
+      }>;
     profilePicture: Schema.Attribute.Media<'images'>;
     provider: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
@@ -1253,17 +1253,17 @@ export interface PluginUsersPermissionsUser
     >;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
-    Schema.Attribute.Private;
+      Schema.Attribute.Private;
     userEvents: Schema.Attribute.Relation<
       'oneToMany',
       'api::user-event.user-event'
     >;
     username: Schema.Attribute.String &
-    Schema.Attribute.Required &
-    Schema.Attribute.Unique &
-    Schema.Attribute.SetMinMaxLength<{
-      minLength: 3;
-    }>;
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 3;
+      }>;
   };
 }
 


### PR DESCRIPTION
[ ISSUE ] Keycloak didn't map all provider claims to strapi user fields (ex. family_name didn't map to strapi's lastName user field).

[ SOLUTION ]
The **authCallback return object** maps directly to Strapi user fields => pull additional claims from body and return them. 
This function runs after authentication succeeds and is responsible for fetching user data from the provider & returning it in a format Strapi understands.

[ CHANGES ]
1. Get the default built-in Keycloak provider from Strapi
2. Re-register it with a custom authCallback (override it) which calls Keycloak’s `/userinfo` endpoint using the access token
4. Map the response to Strapi user format; this is where we map Keycloak fields → Strapi user fields

[ ADDITIONAL CHANGE ]
Cleaner organization: Refactored the code in `cms/src/index.ts`; moved the `saveFcmToken` handler and `/auth/fcmToken` route to the `extensions/users-permission` folder