### PR TITLE
New endpoint for Projects + Cron function

### DIFF
--- a/cms/.env.example
+++ b/cms/.env.example
@@ -5,3 +5,6 @@ API_TOKEN_SALT=tobemodified
 ADMIN_JWT_SECRET=tobemodified
 TRANSFER_TOKEN_SALT=tobemodified
 JWT_SECRET=tobemodified
+GITHUB_TOKEN=tobemodified
+GITHUB_ORG=base42
+PROJECT_SYNC_SECRET=tobemodified

--- a/cms/config/cron-tasks.ts
+++ b/cms/config/cron-tasks.ts
@@ -1,0 +1,12 @@
+export default {
+  '0 */2 * * *': async ({ strapi }) => {
+    try {
+      const result = await strapi.service('api::project.project' as any).syncProjects();
+      strapi.log.info(
+        `[Project Sync] Completed: ${result.synced_repos}/${result.total_repos} synced, ${result.failed_repos} failed`
+      );
+    } catch (error) {
+      strapi.log.error('[Project Sync] Cron sync failed', error);
+    }
+  },
+};

--- a/cms/config/server.ts
+++ b/cms/config/server.ts
@@ -1,8 +1,19 @@
+import cronTasks from './cron-tasks';
+
 export default ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
   app: {
     keys: env.array('APP_KEYS'),
+  },
+  githubToken: env('GITHUB_TOKEN'),
+  githubOrg: env('GITHUB_ORG', 'base42'),
+  projectSyncSecret: env('PROJECT_SYNC_SECRET'),
+  cron: {
+    enabled: true,
+    tasks: {
+      ...cronTasks,
+    },
   },
   webhooks: {
     populateRelations: env.bool('WEBHOOKS_POPULATE_RELATIONS', false),

--- a/cms/src/api/project/content-types/project/schema.json
+++ b/cms/src/api/project/content-types/project/schema.json
@@ -1,0 +1,59 @@
+{
+  "kind": "collectionType",
+  "collectionName": "projects",
+  "info": {
+    "singularName": "project",
+    "pluralName": "projects",
+    "displayName": "Project",
+    "description": "Cached GitHub repositories for mobile app consumption"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "github_repo_id": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "description": {
+      "type": "text"
+    },
+    "language": {
+      "type": "string"
+    },
+    "stargazers_count": {
+      "type": "integer",
+      "default": 0
+    },
+    "owner_login": {
+      "type": "string",
+      "required": true
+    },
+    "pushed_at": {
+      "type": "datetime"
+    },
+    "pr_count": {
+      "type": "integer",
+      "default": 0
+    },
+    "help_wanted_count": {
+      "type": "integer",
+      "default": 0
+    },
+    "contributors": {
+      "type": "json"
+    },
+    "commit_activity": {
+      "type": "json"
+    },
+    "last_synced_at": {
+      "type": "datetime"
+    }
+  }
+}

--- a/cms/src/api/project/controllers/project.ts
+++ b/cms/src/api/project/controllers/project.ts
@@ -1,0 +1,49 @@
+import { factories } from "@strapi/strapi";
+
+const PROJECT_UID = "api::project.project" as any;
+
+const PROJECT_PUBLIC_FIELDS = [
+  "name",
+  "description",
+  "language",
+  "stargazers_count",
+  "owner_login",
+  "pushed_at",
+  "pr_count",
+  "help_wanted_count",
+  "contributors",
+  "commit_activity",
+  "last_synced_at",
+] as const;
+
+export default factories.createCoreController(PROJECT_UID, ({ strapi }) => ({
+  async find(ctx) {
+    const baseQuery = await this.sanitizeQuery(ctx);
+
+    const sanitizedQuery = {
+      ...baseQuery,
+      fields: [...PROJECT_PUBLIC_FIELDS],
+      sort: baseQuery.sort ?? ["stargazers_count:desc", "pushed_at:desc"],
+      pagination: baseQuery.pagination ?? { pageSize: 100 },
+    };
+
+    const { results, pagination } = await strapi
+      .service(PROJECT_UID)
+      .find(sanitizedQuery);
+    const sanitizedResults = await this.sanitizeOutput(results, ctx);
+
+    return this.transformResponse(sanitizedResults, { pagination });
+  },
+
+  async sync(ctx) {
+    const headerSecret = ctx.request.headers["x-project-sync-secret"];
+    const configuredSecret = strapi.config.get("server.projectSyncSecret");
+
+    if (!configuredSecret || headerSecret !== configuredSecret) {
+      return ctx.unauthorized("Invalid sync secret");
+    }
+
+    const result = await strapi.service(PROJECT_UID).syncProjects();
+    ctx.body = result;
+  },
+}));

--- a/cms/src/api/project/routes/project.ts
+++ b/cms/src/api/project/routes/project.ts
@@ -1,0 +1,3 @@
+import { factories } from '@strapi/strapi';
+
+export default factories.createCoreRouter('api::project.project' as any);

--- a/cms/src/api/project/routes/sync.ts
+++ b/cms/src/api/project/routes/sync.ts
@@ -1,0 +1,12 @@
+export default {
+  routes: [
+    {
+      method: 'POST',
+      path: '/projects/sync',
+      handler: 'project.sync',
+      config: {
+        auth: false,
+      },
+    },
+  ],
+};

--- a/cms/src/api/project/services/project.ts
+++ b/cms/src/api/project/services/project.ts
@@ -1,0 +1,224 @@
+import { factories } from "@strapi/strapi";
+
+const PROJECT_UID = "api::project.project" as any;
+
+const GITHUB_API_BASE = "https://api.github.com";
+const COMMIT_ACTIVITY_RETRY_COUNT = 3;
+const COMMIT_ACTIVITY_RETRY_DELAY_MS = 2000;
+const REPO_SYNC_CONCURRENCY = 5;
+
+type GitHubRepo = {
+  id: number;
+  name: string;
+  description: string | null;
+  language: string | null;
+  stargazers_count: number;
+  updated_at: string;
+  owner: {
+    login: string;
+  };
+};
+
+type GitHubContributor = {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+  contributions: number;
+};
+
+type GitHubCommitActivityWeek = {
+  week: number;
+  total: number;
+  days: number[];
+};
+
+const sleep = async (ms: number) => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const mapWithConcurrency = async <T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> => {
+  const results: R[] = [];
+  let index = 0;
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    async () => {
+      while (index < items.length) {
+        const currentIndex = index;
+        index += 1;
+
+        results[currentIndex] = await mapper(items[currentIndex]);
+      }
+    },
+  );
+
+  await Promise.all(workers);
+  return results;
+};
+
+export default factories.createCoreService(PROJECT_UID, ({ strapi }) => ({
+  async syncProjects() {
+    const githubToken = strapi.config.get<string>("server.githubToken");
+    const githubOrg = strapi.config.get<string>("server.githubOrg") || "base42";
+
+    if (!githubToken) {
+      throw new Error("Missing GITHUB_TOKEN in environment");
+    }
+
+    const requestGitHub = async <T>(path: string): Promise<T> => {
+      const response = await fetch(`${GITHUB_API_BASE}${path}`, {
+        headers: {
+          Accept: "application/vnd.github+json",
+          Authorization: `Bearer ${githubToken}`,
+          "User-Agent": "base42-cms-project-sync",
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      });
+
+      if (!response.ok) {
+        const bodyText = await response.text();
+        throw new Error(
+          `GitHub request failed (${response.status}) for ${path}: ${bodyText}`,
+        );
+      }
+
+      return (await response.json()) as T;
+    };
+
+    const requestCommitActivity = async (
+      repoName: string,
+    ): Promise<GitHubCommitActivityWeek[]> => {
+      const path = `/repos/${githubOrg}/${repoName}/stats/commit_activity`;
+
+      for (
+        let attempt = 0;
+        attempt <= COMMIT_ACTIVITY_RETRY_COUNT;
+        attempt += 1
+      ) {
+        const response = await fetch(`${GITHUB_API_BASE}${path}`, {
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${githubToken}`,
+            "User-Agent": "base42-cms-project-sync",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        });
+
+        if (response.status === 202 && attempt < COMMIT_ACTIVITY_RETRY_COUNT) {
+          await sleep(COMMIT_ACTIVITY_RETRY_DELAY_MS);
+          continue;
+        }
+
+        if (!response.ok) {
+          const bodyText = await response.text();
+          throw new Error(
+            `Commit activity request failed (${response.status}) for ${repoName}: ${bodyText}`,
+          );
+        }
+
+        return (await response.json()) as GitHubCommitActivityWeek[];
+      }
+
+      return [];
+    };
+
+    const repos = await requestGitHub<GitHubRepo[]>(
+      `/orgs/${githubOrg}/repos?per_page=100&sort=pushed&direction=desc&type=public`,
+    );
+
+    const syncStartedAt = new Date().toISOString();
+    let syncedCount = 0;
+    let failedCount = 0;
+
+    await mapWithConcurrency(repos, REPO_SYNC_CONCURRENCY, async (repo) => {
+      try {
+        const [pulls, issues, contributors, commitActivity] = await Promise.all(
+          [
+            requestGitHub<unknown[]>(
+              `/repos/${githubOrg}/${repo.name}/pulls?state=open&per_page=100`,
+            ),
+            requestGitHub<unknown[]>(
+              `/repos/${githubOrg}/${repo.name}/issues?labels=help-wanted&state=open&per_page=100`,
+            ),
+            requestGitHub<GitHubContributor[]>(
+              `/repos/${githubOrg}/${repo.name}/contributors?per_page=10`,
+            ),
+            requestCommitActivity(repo.name),
+          ],
+        );
+
+        const helpWantedCount = issues.filter(
+          (issue) => !(issue as { pull_request?: unknown }).pull_request,
+        ).length;
+
+        const normalizedContributors = contributors.map((contributor) => ({
+          login: contributor.login,
+          avatar_url: contributor.avatar_url,
+          html_url: contributor.html_url,
+          contributions: contributor.contributions,
+        }));
+
+        const data = {
+          github_repo_id: String(repo.id),
+          name: repo.name,
+          description: repo.description,
+          language: repo.language,
+          stargazers_count: repo.stargazers_count,
+          owner_login: repo.owner.login,
+          pushed_at: repo.updated_at,
+          pr_count: pulls.length,
+          help_wanted_count: helpWantedCount,
+          contributors: normalizedContributors,
+          commit_activity: commitActivity,
+          last_synced_at: syncStartedAt,
+        };
+
+        const existingDraft = await strapi.documents(PROJECT_UID).findMany({
+          filters: { github_repo_id: String(repo.id) },
+          fields: ["documentId"],
+          status: "draft",
+        } as any);
+
+        const existingPublished =
+          existingDraft.length > 0
+            ? []
+            : await strapi.documents(PROJECT_UID).findMany({
+                filters: { github_repo_id: String(repo.id) },
+                fields: ["documentId"],
+                status: "published",
+              } as any);
+
+        const existing = existingDraft[0] ?? existingPublished[0];
+
+        if (existing) {
+          await strapi.documents(PROJECT_UID).update({
+            documentId: existing.documentId,
+            data,
+            status: "published",
+          } as any);
+        } else {
+          await strapi.documents(PROJECT_UID).create({
+            data,
+            status: "published",
+          } as any);
+        }
+
+        syncedCount += 1;
+      } catch (error) {
+        failedCount += 1;
+        strapi.log.error(`Failed to sync repo ${repo.name}`, error);
+      }
+    });
+
+    return {
+      total_repos: repos.length,
+      synced_repos: syncedCount,
+      failed_repos: failedCount,
+      synced_at: syncStartedAt,
+    };
+  },
+}));


### PR DESCRIPTION
- Adds Project content type
- Implements sync service that fetches repos from GitHub API
- Creates GET /api/projects endpoint for mobile app
- Creates POST /api/projects/sync with secret-header protection for manual admin sync
- Cron job runs every 2 hours to keep data fresh

NEEDS REVIEW