### PR TITLE
[FIX] Profile update validation logic

### DIFF
--- a/cms/src/extensions/users-permissions/controllers/user.ts
+++ b/cms/src/extensions/users-permissions/controllers/user.ts
@@ -11,31 +11,32 @@ const USERNAME_REGEX = /^[a-z0-9_]{3,20}$/;
 const NAME_REGEX = /^[a-zA-Z\s\-'.]+$/;
 const SANITIZE_REGEX = /[<>\"'&]/g;
 
-function validateNameFields(fieldName: string, value: string, ctx: any) {
+class ValidationError extends Error {}
+
+function validateNameFields(fieldName: string, value: string) {
   if (typeof value !== 'string' || value.length === 0) {
-    return ctx.badRequest(`${fieldName} cannot be empty`);
+    throw new ValidationError(`${fieldName} cannot be empty`);
   } else if (value.length < 2) {
-    return ctx.badRequest(`${fieldName} must be at least 2 characters`);
+    throw new ValidationError(`${fieldName} must be at least 2 characters`);
   } else if (value.length > 50) {
-    return ctx.badRequest(`${fieldName} must be 50 characters or less`);
+    throw new ValidationError(`${fieldName} must be 50 characters or less`);
   } else if (!NAME_REGEX.test(value)) {
-    return ctx.badRequest(`${fieldName} contains invalid characters`);
+    throw new ValidationError(`${fieldName} contains invalid characters`);
   }
 }
 
-function validateUsername(username: string, ctx: any) {
+function validateUsername(username: string) {
   if (!USERNAME_REGEX.test(username)) {
-     return ctx.badRequest('Username must be 3-20 characters (lowercase letters, numbers, underscores only)');
-  } else {
-    if (RESERVED_NAMES.includes(username)) {
-      return ctx.badRequest('This username is reserved');
-    }
+    throw new ValidationError('Username must be 3-20 characters (lowercase letters, numbers, underscores only)');
+  }
+  if (RESERVED_NAMES.includes(username)) {
+    throw new ValidationError('This username is reserved');
   }
 }
 
-function validateProfilePictureId(id: any, ctx: any) {
+function validateProfilePictureId(id: any) {
   if (typeof id !== 'number' || id <= 0 || isNaN(id)) {
-    return ctx.badRequest('Invalid profile picture ID');
+    throw new ValidationError('Invalid profile picture ID');
   }
 }
 
@@ -44,6 +45,7 @@ export default {
     if (!ctx.state.user) return ctx.unauthorized();
 
     const body = ctx.request.body as UpdateProfileBody;
+
     const safeData = Object.fromEntries(
       Object.entries(body).filter(([key]) => ALLOWED_FIELDS.includes(key))
     );
@@ -52,58 +54,57 @@ export default {
       return ctx.badRequest('No valid fields to update');
     }
 
-    if (safeData.username) {
-      safeData.username = safeData.username.trim().toLowerCase();
-      validateUsername(safeData.username, ctx);
+    try {
+      if (safeData.username && safeData.username.length > 0) {
+        safeData.username = safeData.username.trim().toLowerCase();
+        validateUsername(safeData.username);
 
-      const existingUser = await strapi.db.query('plugin::users-permissions.user').findOne({
-        where: { username: safeData.username },
-      });
-      if (existingUser && existingUser.id !== ctx.state.user.id) {
-        return ctx.badRequest('Username is already taken');
+        const existingUser = await strapi.db.query('plugin::users-permissions.user').findOne({
+          where: { username: safeData.username },
+        });
+        if (existingUser && existingUser.id !== ctx.state.user.id) {
+          throw new ValidationError('Username is already taken');
+        }
       }
-    }
 
-    if (safeData.firstName) {
-      safeData.firstName = safeData.firstName.trim();
-      validateNameFields('First name', safeData.firstName, ctx);
-      safeData.firstName = safeData.firstName.replace(SANITIZE_REGEX, '');
-    }
+      if (safeData.firstName && safeData.firstName.length > 0) {
+        safeData.firstName = safeData.firstName.trim();
+        validateNameFields('First name', safeData.firstName);
+        safeData.firstName = safeData.firstName.replace(SANITIZE_REGEX, '');
+      }
 
-    if (safeData.lastName) {
-      safeData.lastName = safeData.lastName.trim();
-      validateNameFields('Last name', safeData.lastName, ctx);
-      safeData.lastName = safeData.lastName.replace(SANITIZE_REGEX, '');
-    }
+      if (safeData.lastName && safeData.lastName.length > 0) {
+        safeData.lastName = safeData.lastName.trim();
+        validateNameFields('Last name', safeData.lastName);
+        safeData.lastName = safeData.lastName.replace(SANITIZE_REGEX, '');
+      }
 
-    if (typeof safeData.profilePicture === 'string' && safeData.profilePicture.trim() !== '') {
-      safeData.profilePicture = parseInt(safeData.profilePicture, 10);
-      validateProfilePictureId(safeData.profilePicture, ctx);
+      if (typeof safeData.profilePicture === 'string' && safeData.profilePicture.trim() !== '') {
+        safeData.profilePicture = parseInt(safeData.profilePicture, 10);
+        validateProfilePictureId(safeData.profilePicture);
 
-      try {
         const media = await strapi.db.query('plugin::upload.file').findOne({
           where: { id: safeData.profilePicture },
           select: ['id', 'name', 'mime', 'size'],
         });
         const maxSizeKB = 10 * 1024;
 
-        if (!media) return ctx.badRequest('Profile picture not found');
-        if (!media.mime.startsWith('image/')) return ctx.badRequest('Profile picture must be an image');
-        if (media.size > maxSizeKB) return ctx.badRequest('Profile picture must be smaller than 10MB');
-      } catch (error) {
-        return ctx.internalServerError('Failed to validate profile picture');
+        if (!media) throw new ValidationError('Profile picture not found');
+        if (!media.mime.startsWith('image/')) throw new ValidationError('Profile picture must be an image');
+        if (media.size > maxSizeKB) throw new ValidationError('Profile picture must be smaller than 10MB');
       }
-    }
 
-    try {
       const updated = await strapi.documents('plugin::users-permissions.user').update({
         documentId: ctx.state.user.documentId,
         data: safeData,
       });
 
-      const { password, resetPasswordToken, confirmationToken, ...safeUser } = updated;
+      const { password, resetPasswordToken, confirmationToken, fcmToken, ...safeUser } = updated;
       ctx.body = safeUser;
     } catch (error) {
+      if (error instanceof ValidationError) {
+        return ctx.badRequest(error.message);
+      }
       return ctx.internalServerError('Failed to update profile');
     }
   },


### PR DESCRIPTION
[ ISSUE ] 
Validators returned status 400, but they didn't stop execution; the caller handler never returned on those values, so execution falls through to the update regardless.

[ SOLUTION ]
Validators now throw `new Error(message)` instead of taking ctx and returning responses; they're pure validation functions with no framework coupling. The controller catches the error & maps it to ctx.badRequest(error.message).