### PR TITLE
Automated event creation for submitted event requests

### DIFF
--- a/cms/src/api/event-request/content-types/event-request/schema.json
+++ b/cms/src/api/event-request/content-types/event-request/schema.json
@@ -56,6 +56,16 @@
     },
     "physicalPresence": {
       "type": "boolean"
+    },
+    "status": {
+      "type": "enumeration",
+      "enum": ["pending", "approved"],
+      "default": "pending"
+    },
+    "event": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::event.event"
     }
   }
 }

--- a/cms/src/api/event-request/controllers/event-request.ts
+++ b/cms/src/api/event-request/controllers/event-request.ts
@@ -6,11 +6,16 @@ import { factories } from '@strapi/strapi'
 
 export default factories.createCoreController('api::event-request.event-request', ({ strapi }) => ({
   async approve(ctx) {
+    const user = ctx.state?.user;
+    if (!user) {
+      return ctx.unauthorized();
+    }
+
     const { id } = ctx.params;
 
-    const request: any = await strapi.documents('api::event-request.event-request').findOne({
+    const request = await strapi.documents('api::event-request.event-request').findOne({
       documentId: id,
-      populate: ['event' as any],
+      populate: { event: true },
     });
 
     if (!request) {
@@ -32,7 +37,7 @@ export default factories.createCoreController('api::event-request.event-request'
 
       await strapi.documents('api::event-request.event-request').update({
         documentId: id,
-        data: { status: 'approved' } as any,
+        data: { status: 'approved' } as Record<string, unknown>,
       });
 
       await strapi.plugins['email'].services.email.send({

--- a/cms/src/api/event-request/controllers/event-request.ts
+++ b/cms/src/api/event-request/controllers/event-request.ts
@@ -4,4 +4,54 @@
 
 import { factories } from '@strapi/strapi'
 
-export default factories.createCoreController('api::event-request.event-request');
+export default factories.createCoreController('api::event-request.event-request', ({ strapi }) => ({
+  async approve(ctx) {
+    const { id } = ctx.params;
+
+    const request: any = await strapi.documents('api::event-request.event-request').findOne({
+      documentId: id,
+      populate: ['event' as any],
+    });
+
+    if (!request) {
+      return ctx.notFound('Event request not found');
+    }
+
+    if (!request.event) {
+      return ctx.badRequest('No linked draft event found');
+    }
+
+    if (request.status === 'approved') {
+      return ctx.badRequest('Event request already approved');
+    }
+
+    try {
+      await strapi.documents('api::event.event').publish({
+        documentId: request.event.documentId,
+      });
+
+      await strapi.documents('api::event-request.event-request').update({
+        documentId: id,
+        data: { status: 'approved' } as any,
+      });
+
+      await strapi.plugins['email'].services.email.send({
+        to: request.initiatorEmail,
+        from: 'hello@42.mk',
+        replyTo: 'hello@42.mk',
+        subject: 'Your event has been approved! - 42.mk',
+        html: `
+          <p>Great news! Your event request "<strong>${request.eventName}</strong>" has been approved and is now published.</p>
+          <p>You can view it on our platform.</p>
+          <p>Best regards,<br/>42.mk Team</p>
+        `,
+      });
+
+      ctx.body = { message: 'Event request approved' };
+    } catch (error) {
+      strapi.log.error('Error approving event request:', error);
+      ctx.status = 500;
+      ctx.body = { error: { message: 'Failed to approve event request' } };
+    }
+  },
+}));

--- a/cms/src/api/event-request/controllers/event-request.ts
+++ b/cms/src/api/event-request/controllers/event-request.ts
@@ -13,10 +13,16 @@ export default factories.createCoreController('api::event-request.event-request'
 
     const { id } = ctx.params;
 
-    const request = await strapi.documents('api::event-request.event-request').findOne({
+        const request = (await strapi.documents('api::event-request.event-request').findOne({
       documentId: id,
-      populate: { event: true },
-    });
+      populate: { event: true } as never,
+    })) as {
+      documentId: string;
+      status?: string;
+      initiatorEmail?: string;
+      eventName?: string;
+      event?: { documentId: string } | null;
+    } | null; 
 
     if (!request) {
       return ctx.notFound('Event request not found');

--- a/cms/src/api/event-request/controllers/form.ts
+++ b/cms/src/api/event-request/controllers/form.ts
@@ -52,6 +52,24 @@ export default {
         data: eventRequest,
       });
 
+      const startDateTime = `${eventRequest.eventDate}T${eventRequest.eventStart}`;
+
+      const draftEvent = await strapi.documents("api::event.event").create({
+        data: {
+          title: eventRequest.eventName,
+          description: `${eventRequest.eventPurpose}\n\n${eventRequest.eventTheme}`,
+          start: startDateTime,
+          summary: eventRequest.eventAgenda,
+          tags: eventRequest.eventTheme ? [{ tagName: eventRequest.eventTheme }] : [],
+        },
+        status: "draft",
+      });
+
+      await strapi.documents("api::event-request.event-request").update({
+        documentId: res.documentId,
+        data: { event: draftEvent.documentId } as any,
+      });
+
       const requestCopy = `<p><strong>Organizing entity</strong>: ${eventRequest.organizingEntity}</p>
       <p><strong>Initiator name</strong>: ${eventRequest.initiatorName}</p>
       <p><strong>Initiator email</strong>: ${eventRequest.initiatorEmail}</p>

--- a/cms/src/api/event-request/controllers/form.ts
+++ b/cms/src/api/event-request/controllers/form.ts
@@ -17,7 +17,7 @@ const formToJsonMap = {
 };
 
 export default {
-  async submit(ctx: any, next) {
+  async submit(ctx, next) {
     const body = ctx.request.body;
 
     try {
@@ -42,7 +42,7 @@ export default {
           acc[mappedKey] = value;
         }
         return acc;
-      }, {} as any);
+      }, {} as Record<string, unknown>);
 
       eventRequest.physicalPresence = eventRequest.physicalPresence === "yes";
       eventRequest.eventStart += ":00";
@@ -67,7 +67,7 @@ export default {
 
       await strapi.documents("api::event-request.event-request").update({
         documentId: res.documentId,
-        data: { event: draftEvent.documentId } as any,
+        data: { event: draftEvent.documentId } as Record<string, unknown>,
       });
 
       const requestCopy = `<p><strong>Organizing entity</strong>: ${eventRequest.organizingEntity}</p>

--- a/cms/src/api/event-request/routes/custom-event-request.ts
+++ b/cms/src/api/event-request/routes/custom-event-request.ts
@@ -1,0 +1,13 @@
+export default {
+  routes: [
+    {
+      method: 'POST',
+      path: '/event-requests/:id/approve',
+      handler: 'event-request.approve',
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+  ],
+};

--- a/cms/src/api/event-request/routes/event-request.ts
+++ b/cms/src/api/event-request/routes/event-request.ts
@@ -2,6 +2,16 @@
  * event-request router
  */
 
-import { factories } from '@strapi/strapi';
-
-export default factories.createCoreRouter('api::event-request.event-request');
+export default {
+  routes: [
+    {
+      method: 'POST',
+      path: '/event-requests/:id/approve',
+      handler: 'event-request.approve',
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+  ],
+};

--- a/cms/src/api/event-request/routes/event-request.ts
+++ b/cms/src/api/event-request/routes/event-request.ts
@@ -1,17 +1,3 @@
-/**
- * event-request router
- */
+import { factories } from '@strapi/strapi';
 
-export default {
-  routes: [
-    {
-      method: 'POST',
-      path: '/event-requests/:id/approve',
-      handler: 'event-request.approve',
-      config: {
-        policies: [],
-        middlewares: [],
-      },
-    },
-  ],
-};
+export default factories.createCoreRouter('api::event-request.event-request');

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -5,6 +5,55 @@ import { eventNotificationMiddleware } from './middlewares/event-notifications';
 
 const FIREBASE_FCM_CREDENTIALS_PATH = './base42-mobile-app-fcm-firebase-adminsdk.json';
 
+const eventRequestApprovalMiddleware = () => {
+  return async (context, next) => {
+    if (context.uid !== 'api::event.event') {
+      return await next();
+    }
+
+    const result = await next();
+
+    if (context.action === 'publish' && result?.documentId) {
+      try {
+        const request = await strapi.db.query('api::event-request.event-request').findOne({
+          where: {
+            event: { documentId: result.documentId },
+          },
+        });
+
+        if (request && request.status !== 'approved') {
+          await strapi.documents('api::event-request.event-request').update({
+            documentId: request.documentId,
+            data: { status: 'approved' } as any,
+          });
+
+          const reqDetails = await strapi.db.query('api::event-request.event-request').findOne({
+            where: { documentId: request.documentId },
+          });
+
+          if (reqDetails?.initiatorEmail) {
+            await strapi.plugins['email'].services.email.send({
+              to: reqDetails.initiatorEmail,
+              from: 'hello@42.mk',
+              replyTo: 'hello@42.mk',
+              subject: 'Your event has been approved! - 42.mk',
+              html: `
+                <p>Great news! Your event request "<strong>${reqDetails.eventName}</strong>" has been approved and is now published.</p>
+                <p>You can view it on our platform.</p>
+                <p>Best regards,<br/>42.mk Team</p>
+              `,
+            });
+          }
+        }
+      } catch (error) {
+        strapi.log.error('[Event Request Approval] Error syncing status after publish:', error);
+      }
+    }
+
+    return result;
+  };
+};
+
 export default {
   /**
    * An asynchronous register function that runs before
@@ -42,6 +91,7 @@ export default {
     });
 
     strapi.documents.use(eventNotificationMiddleware());
+    strapi.documents.use(eventRequestApprovalMiddleware());
   },
 
   /**

--- a/cms/src/index.ts
+++ b/cms/src/index.ts
@@ -2,57 +2,9 @@
 const admin = require('firebase-admin');
 import fs from 'fs/promises';
 import { eventNotificationMiddleware } from './middlewares/event-notifications';
+import { eventRequestApprovalMiddleware } from './middlewares/event-request-approval';
 
 const FIREBASE_FCM_CREDENTIALS_PATH = './base42-mobile-app-fcm-firebase-adminsdk.json';
-
-const eventRequestApprovalMiddleware = () => {
-  return async (context, next) => {
-    if (context.uid !== 'api::event.event') {
-      return await next();
-    }
-
-    const result = await next();
-
-    if (context.action === 'publish' && result?.documentId) {
-      try {
-        const request = await strapi.db.query('api::event-request.event-request').findOne({
-          where: {
-            event: { documentId: result.documentId },
-          },
-        });
-
-        if (request && request.status !== 'approved') {
-          await strapi.documents('api::event-request.event-request').update({
-            documentId: request.documentId,
-            data: { status: 'approved' } as any,
-          });
-
-          const reqDetails = await strapi.db.query('api::event-request.event-request').findOne({
-            where: { documentId: request.documentId },
-          });
-
-          if (reqDetails?.initiatorEmail) {
-            await strapi.plugins['email'].services.email.send({
-              to: reqDetails.initiatorEmail,
-              from: 'hello@42.mk',
-              replyTo: 'hello@42.mk',
-              subject: 'Your event has been approved! - 42.mk',
-              html: `
-                <p>Great news! Your event request "<strong>${reqDetails.eventName}</strong>" has been approved and is now published.</p>
-                <p>You can view it on our platform.</p>
-                <p>Best regards,<br/>42.mk Team</p>
-              `,
-            });
-          }
-        }
-      } catch (error) {
-        strapi.log.error('[Event Request Approval] Error syncing status after publish:', error);
-      }
-    }
-
-    return result;
-  };
-};
 
 export default {
   /**

--- a/cms/src/middlewares/event-request-approval.ts
+++ b/cms/src/middlewares/event-request-approval.ts
@@ -1,0 +1,48 @@
+export const eventRequestApprovalMiddleware = () => {
+  return async (context, next) => {
+    if (context.uid !== 'api::event.event') {
+      return await next();
+    }
+
+    const result = await next();
+
+    if (context.action === 'publish' && result?.documentId) {
+      try {
+        const request = await strapi.db.query('api::event-request.event-request').findOne({
+          where: {
+            event: { documentId: result.documentId },
+          },
+        });
+
+        if (request && request.status !== 'approved') {
+          await strapi.documents('api::event-request.event-request').update({
+            documentId: request.documentId,
+            data: { status: 'approved' } as Record<string, unknown>,
+          });
+
+          const reqDetails = await strapi.db.query('api::event-request.event-request').findOne({
+            where: { documentId: request.documentId },
+          });
+
+          if (reqDetails?.initiatorEmail) {
+            await strapi.plugins['email'].services.email.send({
+              to: reqDetails.initiatorEmail,
+              from: 'hello@42.mk',
+              replyTo: 'hello@42.mk',
+              subject: 'Your event has been approved! - 42.mk',
+              html: `
+                <p>Great news! Your event request "<strong>${reqDetails.eventName}</strong>" has been approved and is now published.</p>
+                <p>You can view it on our platform.</p>
+                <p>Best regards,<br/>42.mk Team</p>
+              `,
+            });
+          }
+        }
+      } catch (error) {
+        strapi.log.error('[Event Request Approval] Error syncing status after publish:', error);
+      }
+    }
+
+    return result;
+  };
+};


### PR DESCRIPTION
- When a user submits a form it creates both an event request and event as  a draft.
- Sets default status value to "pending"
- Links them together via ID
- If event gets published -> hook changes status to "approved" -> sends email to user that the event has been approved -> adds event to collection.